### PR TITLE
fix null block | basic 1.21.3 support

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -10,5 +10,5 @@ repositories {
 }
 
 dependencies {
-    compileOnly("io.papermc.paper:paper-api:1.21.1-R0.1-SNAPSHOT")
+    compileOnly("io.papermc.paper:paper-api:1.21.3-R0.1-SNAPSHOT")
 }

--- a/bukkit/build.gradle
+++ b/bukkit/build.gradle
@@ -15,5 +15,5 @@ dependencies {
     implementation project(':shared')
     implementation project(':api')
     compileOnly 'com.comphenix.protocol:ProtocolLib:5.3.0'
-    compileOnly("io.papermc.paper:paper-api:1.21.1-R0.1-SNAPSHOT")
+    compileOnly("io.papermc.paper:paper-api:1.21.3-R0.1-SNAPSHOT")
 }

--- a/bukkit/src/main/java/com/lauriethefish/betterportals/bukkit/player/view/block/PlayerBlockView.java
+++ b/bukkit/src/main/java/com/lauriethefish/betterportals/bukkit/player/view/block/PlayerBlockView.java
@@ -146,6 +146,8 @@ public class PlayerBlockView implements IPlayerBlockView   {
 
                         PacketContainer nbtUpdatePacket = viewableBlockArray.getDestinationTileEntityPacket(blockInfo.getOriginPos());
                         if (nbtUpdatePacket != null) {
+                            if (nbtUpdatePacket.getBlocks() != null)
+                                continue;
                             queuedTileEntityUpdates.add(nbtUpdatePacket);
                             logger.fine("Queueing tile state update at destination");
                         }
@@ -156,6 +158,8 @@ public class PlayerBlockView implements IPlayerBlockView   {
 
                         PacketContainer nbtUpdatePacket = viewableBlockArray.getOriginTileEntityPacket(blockInfo.getOriginPos());
                         if (nbtUpdatePacket != null) {
+                            if (nbtUpdatePacket.getBlocks() != null)
+                                continue;
                             queuedTileEntityUpdates.add(nbtUpdatePacket);
                             logger.fine("Queueing tile state update at origin");
                         }


### PR DESCRIPTION
While this is a hotfix, this does fix the crashing that has been happening with 1.21.1+ users as noted in spigot page

Error that happens without the null check:
```
20:07:23] [Netty Epoll Server IO #2/ERROR]: Error sending packet clientbound/minecraft:block_entity_data (skippable? false)
io.netty.handler.codec.EncoderException: Failed to encode packet 'clientbound/minecraft:block_entity_data'
	at net.minecraft.network.codec.IdDispatchCodec.encode(IdDispatchCodec.java:53) ~[purpur-1.21.3.jar:1.21.3-2358-16ce24a]
	at net.minecraft.network.codec.IdDispatchCodec.encode(IdDispatchCodec.java:20) ~[purpur-1.21.3.jar:1.21.3-2358-16ce24a]
	at net.minecraft.network.PacketEncoder.encode(PacketEncoder.java:26) ~[purpur-1.21.3.jar:1.21.3-2358-16ce24a]
	at net.minecraft.network.PacketEncoder.encode(PacketEncoder.java:12) ~[purpur-1.21.3.jar:1.21.3-2358-16ce24a]
	at io.netty.handler.codec.MessageToByteEncoder.write(MessageToByteEncoder.java:107) ~[netty-codec-4.1.97.Final.jar:4.1.97.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeWrite0(AbstractChannelHandlerContext.java:881) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeWrite(AbstractChannelHandlerContext.java:863) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
	at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:968) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
	at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:856) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
	at io.netty.handler.codec.MessageToMessageEncoder.write(MessageToMessageEncoder.java:113) ~[netty-codec-4.1.97.Final.jar:4.1.97.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeWrite0(AbstractChannelHandlerContext.java:881) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeWrite(AbstractChannelHandlerContext.java:863) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
	at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:968) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
	at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:856) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
	at io.netty.handler.codec.MessageToByteEncoder.write(MessageToByteEncoder.java:120) ~[netty-codec-4.1.97.Final.jar:4.1.97.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeWrite0(AbstractChannelHandlerContext.java:881) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeWrite(AbstractChannelHandlerContext.java:863) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
	at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:968) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
	at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:856) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
	at io.netty.channel.ChannelOutboundHandlerAdapter.write(ChannelOutboundHandlerAdapter.java:113) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
	at net.minecraft.network.Connection$2.write(Connection.java:771) ~[purpur-1.21.3.jar:1.21.3-2358-16ce24a]
	at io.netty.channel.AbstractChannelHandlerContext.invokeWrite0(AbstractChannelHandlerContext.java:881) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeWrite(AbstractChannelHandlerContext.java:863) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
	at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:968) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
	at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:856) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
	at io.netty.channel.ChannelDuplexHandler.write(ChannelDuplexHandler.java:115) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
	at AntiPopup-10.1.jar/com.github.kaspiandev.antipopup.nms.v1_21_2.PlayerInjector_v1_21_2$1.write(PlayerInjector_v1_21_2.java:53) ~[AntiPopup-10.1.jar:?]
	at io.netty.channel.AbstractChannelHandlerContext.invokeWrite0(AbstractChannelHandlerContext.java:879) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeWrite(AbstractChannelHandlerContext.java:863) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
	at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:968) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
	at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:856) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
	at io.netty.channel.ChannelDuplexHandler.write(ChannelDuplexHandler.java:115) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
	at ViewDistanceTweaks-1.5.7-dev-all.jar/com.froobworld.viewdistancetweaks.limiter.ClientViewDistanceManager$ViewDistancePacketModifier.write(ClientViewDistanceManager.java:112) ~[ViewDistanceTweaks-1.5.7-dev-all.jar:?]
	at io.netty.channel.AbstractChannelHandlerContext.invokeWrite0(AbstractChannelHandlerContext.java:879) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeWriteAndFlush(AbstractChannelHandlerContext.java:940) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
	at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:966) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
	at io.netty.channel.AbstractChannelHandlerContext.writeAndFlush(AbstractChannelHandlerContext.java:934) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
	at io.netty.channel.DefaultChannelPipeline.writeAndFlush(DefaultChannelPipeline.java:1020) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
	at io.netty.channel.AbstractChannel.writeAndFlush(AbstractChannel.java:311) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
	at ProtocolLib.jar/com.comphenix.protocol.injector.netty.channel.NettyChannelProxy.writeAndFlush(NettyChannelProxy.java:227) ~[ProtocolLib.jar:?]
	at ProtocolLib.jar/com.comphenix.protocol.injector.netty.channel.NettyChannelProxy.writeAndFlush(NettyChannelProxy.java:233) ~[ProtocolLib.jar:?]
	at net.minecraft.network.Connection.doSendPacket(Connection.java:513) ~[purpur-1.21.3.jar:1.21.3-2358-16ce24a]
	at net.minecraft.network.Connection.lambda$sendPacket$13(Connection.java:498) ~[purpur-1.21.3.jar:1.21.3-2358-16ce24a]
	at ProtocolLib.jar/com.comphenix.protocol.injector.netty.channel.NettyEventLoopProxy.lambda$proxyRunnable$2(NettyEventLoopProxy.java:49) ~[ProtocolLib.jar:?]
	at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:174) ~[netty-common-4.1.97.Final.jar:4.1.97.Final]
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:167) ~[netty-common-4.1.97.Final.jar:4.1.97.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:470) ~[netty-common-4.1.97.Final.jar:4.1.97.Final]
	at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:413) ~[netty-transport-classes-epoll-4.1.97.Final.jar:4.1.97.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997) ~[netty-common-4.1.97.Final.jar:4.1.97.Final]
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) ~[netty-common-4.1.97.Final.jar:4.1.97.Final]
	at java.base/java.lang.Thread.run(Thread.java:1583) ~[?:?]
Caused by: java.lang.IllegalArgumentException: Can't find id for 'null' in map Registry[ResourceKey[minecraft:root / minecraft:block_entity_type] (Stable)]
	at net.minecraft.core.IdMap.getIdOrThrow(IdMap.java:25) ~[purpur-1.21.3.jar:1.21.3-2358-16ce24a]
	at net.minecraft.network.codec.ByteBufCodecs$25.encode(ByteBufCodecs.java:550) ~[purpur-1.21.3.jar:1.21.3-2358-16ce24a]
	at net.minecraft.network.codec.ByteBufCodecs$25.encode(ByteBufCodecs.java:537) ~[purpur-1.21.3.jar:1.21.3-2358-16ce24a]
	at net.minecraft.network.codec.StreamCodec$9.encode(StreamCodec.java:169) ~[purpur-1.21.3.jar:1.21.3-2358-16ce24a]
	at net.minecraft.network.codec.StreamCodec$5.encode(StreamCodec.java:90) ~[purpur-1.21.3.jar:1.21.3-2358-16ce24a]
	at net.minecraft.network.codec.StreamCodec$5.encode(StreamCodec.java:80) ~[purpur-1.21.3.jar:1.21.3-2358-16ce24a]
	... 51 more
```


I'm assuming minecraft can't have a null block so it rather kick the client out instead of silently rejecting. Has to be a bug further up the chain but this helps with what i'm looking at. Maybe instead of not sending the block at all, all null/unknown blocks should be set to `minecraft:air`